### PR TITLE
Resolved Failed Deploys (WebPack Refference Error : Local Storage)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,9 @@
-import React from "react";
-import { useStaticQuery, graphql } from "gatsby";
-import  "../css/site.css";
-import HomePage from "./HomePage";
-import { Global, css } from "@emotion/core";
-import Reset from "../components/jss/Reset";
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import "../css/site.css"
+import HomePage from "./HomePage"
+import { Global, css } from "@emotion/core"
+import Reset from "../components/jss/Reset"
 
 const IndexPage = () => {
   const data = useStaticQuery(graphql`
@@ -40,19 +40,25 @@ const IndexPage = () => {
 
   const { tracks, events } = data.allAgendaJson.nodes[0]
 
-  if (localStorage.getItem("tracks") === null) {
+  // Donot remove "typeof" : https://github.com/gatsbyjs/gatsby/issues/14480#issuecomment-497983196
+
+  if (
+    typeof window !== "undefined" &&
+    localStorage.getItem("tracks") === null
+  ) {
     localStorage.setItem("tracks", JSON.stringify(tracks))
   }
 
-  if (localStorage.getItem("events") === null) {
+  if (
+    typeof window !== "undefined" &&
+    localStorage.getItem("events") === null
+  ) {
     localStorage.setItem("events", JSON.stringify(events))
   }
-
+  // typeof window !== 'undefined' && # your localStorage
   return (
     <React.Fragment>
-      <Global
-        styles={Reset}
-      />
+      <Global styles={Reset} />
       <HomePage />
     </React.Fragment>
   )


### PR DESCRIPTION
**Error : **
localStorage is available when running 'develop' but the build fails on error "WebpackError: ReferenceError: localStorage is not defined"

**Cause fo Error:**
Basically, when you build, localStorage isn't defined because it's a browser-only feature.

**Solution:**
Added typeof window !== 'undefined' && # your localStorage interaction

**Resource:**
https://github.com/gatsbyjs/gatsby/issues/14480#issuecomment-497983196